### PR TITLE
fix as.tool lua socketcan config

### DIFF
--- a/com/as.tool/lua/can/lascanlib.c
+++ b/com/as.tool/lua/can/lascanlib.c
@@ -97,11 +97,11 @@ static const Can_DeviceOpsType* canOps [] =
 	#endif
 	#else
 	#ifdef USE_LUA_SOCKET_CAN
-	&can_socket_ops,
+	&can_socketwin_ops,
 	#endif
 	#endif
 	#ifdef USE_LUA_SOCKET_CAN
-	&can_socketwin_ops,
+	&can_socket_ops,
 	#endif
 	NULL
 };


### PR DESCRIPTION
In #ifdef __WINDOWS__ ,  the canOps should add can_socketwin_ops, not can_socket_ops.
Out of  #ifdef __WINDOWS__ , which means when in Linux platform, the canOps should add can_socket_ops, not can_socketwin_ops.
It is found by me when using commit 9251d23. At that time, this mistake stopped me from successfully building the project. Therefore, I changed this file com/as.tool/lua/can/lascanlib.c like this PR.
However, I did not encounter hinder again with the newest commit eb96b9c in autosar/as where you fixed some minor issues even this mistake was not included in the issues set.
I guess some repair avoid this mistake occurring when building.
But I thought this code mistake still exists so I proposed this PR.